### PR TITLE
Fix/naming for targets in cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,7 @@ option(BUILD_EXAMPLES "Build short example binaries" ON)
 include(GNUInstallDirs)
 set(project_config_in "${CMAKE_CURRENT_LIST_DIR}/cmake/positioning_systems_apiConfig.cmake.in")
 set(project_config_out "${CMAKE_CURRENT_BINARY_DIR}/positioning_systems_apiConfig.cmake")
-set(config_targets_file_serial_communication "serial_communication.cmake")
-set(config_targets_file_follow_me_driver "follow_me_driver.cmake")
-set(config_targets_file_rtls_driver "rtls_driver.cmake")
-set(config_targets_file_logger "logger.cmake")
+set(positioning_systems_api_targets "positioning_systems_apiTargets")
 set(version_config_file "${CMAKE_CURRENT_BINARY_DIR}/positioning_systems_apiConfigVersion.cmake")
 set(export_dest_dir "lib/cmake/positioning_systems_api")
 
@@ -36,8 +33,24 @@ if(BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
+
+#-------------- Install ---------------#
+install(EXPORT ${positioning_systems_api_targets}
+  DESTINATION "${export_dest_dir}"
+  NAMESPACE positioning_systems_api::
+  FILE "${positioning_systems_api_targets}.cmake"
+  COMPONENT configs
+)
+
 include(CMakePackageConfigHelpers)
-configure_file("${project_config_in}" "${project_config_out}" @ONLY)
+# configure_file("${project_config_in}" "${project_config_out}" @ONLY)
+# generate the config file that is includes the exports
+configure_package_config_file(${project_config_in} ${project_config_out}
+  INSTALL_DESTINATION "${export_dest_dir}"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
+
 write_basic_package_version_file("${version_config_file}" COMPATIBILITY SameMajorVersion)
 
 install(FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(project_config_out "${CMAKE_CURRENT_BINARY_DIR}/positioning_systems_apiConfi
 set(config_targets_file_serial_communication "serial_communication.cmake")
 set(config_targets_file_follow_me_driver "follow_me_driver.cmake")
 set(config_targets_file_rtls_driver "rtls_driver.cmake")
+set(config_targets_file_logger "logger.cmake")
 set(version_config_file "${CMAKE_CURRENT_BINARY_DIR}/positioning_systems_apiConfigVersion.cmake")
 set(export_dest_dir "lib/cmake/positioning_systems_api")
 

--- a/cmake/positioning_systems_apiConfig.cmake.in
+++ b/cmake/positioning_systems_apiConfig.cmake.in
@@ -1,8 +1,6 @@
-set(config_targets_file_serial_communication @config_targets_file_serial_communication@)
-include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file_serial_communication}")
-set(config_targets_file_follow_me_driver @config_targets_file_follow_me_driver@)
-include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file_follow_me_driver}")
-set(config_targets_file_rtls_driver @config_targets_file_rtls_driver@)
-include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file_rtls_driver}")
-set(config_targets_file_logger @config_targets_file_logger@)
-include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file_logger}")
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@positioning_systems_api_targets@.cmake")

--- a/cmake/positioning_systems_apiConfig.cmake.in
+++ b/cmake/positioning_systems_apiConfig.cmake.in
@@ -2,3 +2,7 @@ set(config_targets_file_serial_communication @config_targets_file_serial_communi
 include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file_serial_communication}")
 set(config_targets_file_follow_me_driver @config_targets_file_follow_me_driver@)
 include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file_follow_me_driver}")
+set(config_targets_file_rtls_driver @config_targets_file_rtls_driver@)
+include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file_rtls_driver}")
+set(config_targets_file_logger @config_targets_file_logger@)
+include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file_logger}")

--- a/follow_me_driver/CMakeLists.txt
+++ b/follow_me_driver/CMakeLists.txt
@@ -24,14 +24,7 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${LIB_NAME}
-  EXPORT ${LIB_NAME}
+  EXPORT ${positioning_systems_api_targets}
   DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   COMPONENT libraries
-)
-
-install(EXPORT ${LIB_NAME}
-  DESTINATION "${export_dest_dir}"
-  NAMESPACE positioning_systems_api::
-  FILE ${config_targets_file_follow_me_driver}
-  COMPONENT configs
 )

--- a/logger/CMakeLists.txt
+++ b/logger/CMakeLists.txt
@@ -21,34 +21,25 @@ add_subdirectory(${CMAKE_BINARY_DIR}/spdlog-src
   EXCLUDE_FROM_ALL
 )
 
-set(MODULE_LIBS spdlog_header_only)
-set_target_properties(spdlog_header_only PROPERTIES EXPORT_NAME "positioning_systems_api_spdlog_header_only")
-
-add_library(${LIB_NAME}
+add_library(${LIB_NAME} SHARED
   src/logger.cpp
 )
 
 target_include_directories(${LIB_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/spdlog-src/include/>
   $<INSTALL_INTERFACE:include/>
 )
 
 target_link_libraries(${LIB_NAME} ${MODULE_LIBS})
 
-install(DIRECTORY include/
+install(DIRECTORY include/ ${CMAKE_BINARY_DIR}/spdlog-src/include/
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   COMPONENT headers
 )
 
-install(TARGETS ${LIB_NAME} spdlog_header_only
-  EXPORT ${LIB_NAME}
+install(TARGETS ${LIB_NAME}
+  EXPORT ${positioning_systems_api_targets}
   DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   COMPONENT libraries
-)
-
-install(EXPORT ${LIB_NAME}
-  DESTINATION "${export_dest_dir}"
-  NAMESPACE positioning_systems_api::
-  FILE ${config_targets_file_logger}
-  COMPONENT configs
 )

--- a/rtls_driver/CMakeLists.txt
+++ b/rtls_driver/CMakeLists.txt
@@ -25,14 +25,7 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${LIB_NAME}
-  EXPORT ${LIB_NAME}
+  EXPORT ${positioning_systems_api_targets}
   DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   COMPONENT libraries
-)
-
-install(EXPORT ${LIB_NAME}
-  DESTINATION "${export_dest_dir}"
-  NAMESPACE positioning_systems_api::
-  FILE ${config_targets_file_rtls_driver}
-  COMPONENT configs
 )

--- a/serial_communication/CMakeLists.txt
+++ b/serial_communication/CMakeLists.txt
@@ -25,14 +25,7 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${LIB_NAME}
-  EXPORT ${LIB_NAME}
+  EXPORT ${positioning_systems_api_targets}
   DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   COMPONENT libraries
-)
-
-install(EXPORT ${LIB_NAME}
-  DESTINATION "${export_dest_dir}"
-  NAMESPACE positioning_systems_api::
-  FILE ${config_targets_file_serial_communication}
-  COMPONENT configs
 )


### PR DESCRIPTION
Move targets to a single file called positioning_systems_apiTargets.cmake
Remove spdlog_header_only target